### PR TITLE
Fix creating OWSErrors causing TypeErrors

### DIFF
--- a/OWScript/Errors.py
+++ b/OWScript/Errors.py
@@ -21,7 +21,7 @@ class Logger:
             sys.stderr.write('[DEBUG] {}\n'.format(' '.join(map(str, msg))))
 
 class OWSError(Exception):
-    def __init__(self, msg, pos):
+    def __init__(self, msg, pos=None):
         global TEXT
         if pos:
             line, col = pos


### PR DESCRIPTION
The Parser and the Lexer were throwing TypeErrors instead of OWSErrors when something was wrong.

This sets a default for `pos` in OWSError.\_\_init\_\_, making it truly optional and fixing the TypeErrors