### PR TITLE
Fix text encoding when saving to a file 

### DIFF
--- a/OWScript.py
+++ b/OWScript.py
@@ -31,6 +31,12 @@ def transpile(text, path, args):
     if args.min:
         code = re.sub(r'[\s\n]*', '', code)
     if not args.save:
+        if sys.stdout.encoding == None or sys.stdout.encoding != 'utf-8':
+            sys.stderr.write(
+                '[WARNING] Python encoding output not set to utf-8,'
+                'which might make unicode characters on the output incorrect.'
+                '\nConsider using `set PYTHONIOENCODING=utf_8` and running the command again.'
+            )
         sys.stdout.write(code)
     else:
         with open(args.save, 'wb') as f:

--- a/OWScript.py
+++ b/OWScript.py
@@ -33,7 +33,8 @@ def transpile(text, path, args):
     if not args.save:
         sys.stdout.write(code)
     else:
-        with open(args.save, 'w') as f:
+        with open(args.save, 'wb') as f:
+            code = code.encode('utf-8')
             f.write(code)
     if args.copy:
         import pyperclip


### PR DESCRIPTION
Things like the "ö" in Torbjörn and the "ú" in Lúcio were becoming invalid ascii characters.

Also, added a warning when transpiling directly to the console and the console's encoding isn't utf-8