### PR TITLE
Allow for array creation to have multiple lines

### DIFF
--- a/OWScript/Parser.py
+++ b/OWScript/Parser.py
@@ -515,8 +515,12 @@ class Parser:
         """array : [ arglist? ]"""
         node = Array()
         self.eat('LBRACK')
+        if self.curtype == 'NEWLINE':
+            self.eat('NEWLINE', 'INDENT')
         if self.curtype != 'RBRACK':
             node.elements.extend(self.arglist())
+        if self.curtype == 'NEWLINE':
+            self.eat('NEWLINE', 'DEDENT')
         self.eat('RBRACK')
         return node
 


### PR DESCRIPTION
With this, any of the following ways to create an array is valid and generate the same output.
```
gvar test_variable = [
	1,
	2
]

gvar test_variable = [1,
2]

gvar test_variable = [1,2]

gvar test_variable = [ 1,2 ]

gvar test_variable = [ 1, 2 ]
```