### PR TITLE
 Fix array items from non-constant arrays being transpiled to the value they were defined with

### DIFF
--- a/OWScript/Parser.py
+++ b/OWScript/Parser.py
@@ -478,7 +478,7 @@ class Parser:
 
     def variable(self):
         """variable : GVAR NAME
-                    | PVAR (@ primary)? NAME
+                    | PVAR NAME (@ primary)?
                     | CONST NAME
                     | NAME"""
         pos = self.curpos

--- a/OWScript/Parser.py
+++ b/OWScript/Parser.py
@@ -478,7 +478,7 @@ class Parser:
 
     def variable(self):
         """variable : GVAR NAME
-                    | PVAR NAME (@ primary)?
+                    | PVAR NAME (@ atom)?
                     | CONST NAME
                     | NAME"""
         pos = self.curpos

--- a/OWScript/Parser.py
+++ b/OWScript/Parser.py
@@ -496,7 +496,7 @@ class Parser:
             self.eat('NAME')
             if self.curvalue == '@':
                 self.eat('AT')
-                node.player = self.primary()
+                node.player = self.atom()
         except Errors.ParseError:
             raise Errors.SyntaxError('Invalid variable syntax', pos=pos)
         node._pos = pos

--- a/OWScript/Tokens.py
+++ b/OWScript/Tokens.py
@@ -103,7 +103,7 @@ class Tokens:
     DISABLED : r'DISABLED\b'
     RETURN : r'RETURN\b'
     RULE : r'RULE\b'
-    OWID : fr'(?<!\.)({"|".join(OWID)})(?=([\b\s\n\(\),\.\]]|:[\r\n]))'
+    OWID : fr'(?<!\.)({"|".join(OWID)})(?=([\b\s\n\(\),\.\[\]]|:[\r\n]))'
     ANNOTATION : r'[_a-zA-Z0-9][_a-zA-Z0-9]*:(?![\r\n])'
     RULEBLOCK : r'(EVENT|CONDITIONS|ACTIONS)\b'
     NAME : r'[_a-zA-Z][_\-a-zA-Z0-9]*'

--- a/OWScript/Transpiler.py
+++ b/OWScript/Transpiler.py
@@ -579,10 +579,14 @@ class Transpiler:
                 array = var.value
                 assert type(array) == Array
                 if not 0 <= index < len(array):
-                    item = Number(value='0')
+                    return self.visit(Number(value='0'), scope)
                 else:
-                    item = var.value[index]
-                return self.visit(item, scope)
+                    if var.type == Var.CONST:
+                        return self.visit(var.value[index], scope)
+                    elif var.type == Var.GLOBAL:
+                        return 'Value In Array(Value In Array(Global Variable({})), {}, {})'.format(var.data.letter, var.data.index, index)
+                    elif var.type == Var.PLAYER:
+                        return 'Value In Array(Value In Array(Player Variable({}, {})), {}, {})'.format(var.data.player, var.data.letter, var.data.index, index)
             except AssertionError:
                 raise Errors.SyntaxError('Cannot get item from non-array type {}'.format(type(var.value)), pos=node.parent._pos)
         else:


### PR DESCRIPTION
... instead of a stack of `Value In Array(...)`s

Note that this only changes the behavior of non-constant variables. For optimization purposes, and since constants can't be modified, accessing an element on a constant array still transpiles to the value they were given on initialization.

### Example
```
Rule
	Actions
		gvar global_array = [ 0, Null, False ]
		global_array[0]
		global_array[1]
		global_array[2]

		// old behavior
		const const_array = [ 0, Null, False ]
		const_array[0]
		const_array[1]
		const_array[2]

```
transpiles to
```
rule("") {
    Actions {
        Set Global Variable At Index(A, 1, Append To Array(Append To Array(Append To Array(Empty Array, 0), Null), Null));
        Value In Array(Value In Array(Global Variable(A)), 1, 0);
        Value In Array(Value In Array(Global Variable(A)), 1, 1);
        Value In Array(Value In Array(Global Variable(A)), 1, 2);

        0;
        Null;
        False;
    }
}
```

Fixes #31 