### PR TITLE
Fix target not being read when accessing an array element

### DIFF
--- a/OWScript/Transpiler.py
+++ b/OWScript/Transpiler.py
@@ -602,7 +602,8 @@ class Transpiler:
                     if var.type == Var.GLOBAL:
                         return 'Value In Array(Value In Array(Global Variable({})), {}, {})'.format(var.data.letter, var.data.index, index)
                     elif var.type == Var.PLAYER:
-                        return 'Value In Array(Value In Array(Player Variable({}, {})), {}, {})'.format(var.data.player, var.data.letter, var.data.index, index)
+                        player = self.visit(var.data.player if node.parent.player is None else node.parent.player, scope)
+                        return 'Value In Array(Value In Array(Player Variable({}, {})), {}, {})'.format(player, var.data.letter, var.data.index, index)
                     else:
                         return self.visit(var.value[index], scope)
             except AssertionError:


### PR DESCRIPTION
I was so focused on fixing the syntax error that I completely forgot to check if targets worked.

This fixes
```
pvar array@Cur Elem[0]
```
becoming
```
Value In Array(Value In Array(Player Variable(Event Player, A), 0), 0)
```
instead of

```
Value In Array(Value In Array(Player Variable(Current Array Element, A), 0), 0)
```