### PR TITLE
Allow empty strings combinations

### DIFF
--- a/OWScript/Parser.py
+++ b/OWScript/Parser.py
@@ -60,14 +60,27 @@ class Parser:
             node = String(value='{0}')
             node.children = [formats[0]] + [null] * 2
             return node
-        elif string == ' ':
+        elif string == '':
             node = String(value='')
             node.children = [null] * 3
             return node
+        else:
+            match = re.match(r'^ $| (?: +)$', string)
+            if match:
+                empty_string = String(value='')
+                empty_string.children = [null] * 3
+
+                node = String(value='{0} {1}')
+                node.children = [
+                    empty_string if len(match.group(0)) == 1 else self.parse_string(string[1:], formats, _pos),
+                    empty_string,
+                    null
+                ]
+                return node
         for group in StringConstant.sorted_values:
             for pattern in group:
                 patt = re.sub(r'([^a-zA-Z0-9_\s{}])', r'\\\1', pattern)
-                patt = re.sub(r'{\d}', r'(.+?)', patt) + '$'
+                patt = re.sub(r'{\d}', r'(.*?)', patt) + '$'
                 match = re.match(patt, string, re.I)
                 if match and not match.group(0) == '':
                     groups = match.groups()


### PR DESCRIPTION
- `''` transpiles to `String("", Null, Null, Null)`
- `' '` transpiles to `String("{0} {1}", String("", Null, Null, Null), String("", Null, Null), Null)`
  - works recursively for strings with more than one space

This allows for strings like:
- " Hello", "     Hello" (multiple spaces, even if GitHub doesn't show it), "Hello ", " Hello "
- "Hello::Goodbye" (empty string in between both colons)
- "" (literal empty string)

I tested this with the following code:
```
const ss = [
	`Hello`,
	`Hello `,
	` Hello`,
	` Hello `,
	`Hello {}`(0),
	`Hello / {} - Goodbye`(0),
	``,
	` `,
	`  `,
	`   `,
	` {} `(0),
	`Hello:Goodbye`,
	`Hello::Goodbye`,
	`Hello:::Goodbye`,
	`Hello   / `,
	`#     `,
	`Round      `,
	`-> `,
	`¡ !`
]

Rule "Empty strings"
	Event
		Ongoing - Global
	Actions
		for s in ss:
			Create HUD Text(Everyone, s, null, null, Left, 1, White, White, White, Visible To And String)
```
which in game looked like this:
![image](https://user-images.githubusercontent.com/6181929/63214267-82283a00-c0ec-11e9-8877-118582a5b1fe.png)

If anyone finds a strings that don't parse correctly, let me know.